### PR TITLE
make single execution fuzzy engine faster by using uv_idle_t instead of uv_timer

### DIFF
--- a/lua/popfix/fuzzy_engine.lua
+++ b/lua/popfix/fuzzy_engine.lua
@@ -441,7 +441,9 @@ function M:run_SingleExecutionEngineAgain(opts)
 		else
 			appendAggregateData(tmp, self.numData)
 			self.startingIndex = self.numData + 1
-			self.idle:stop()
+			if self.idle then
+				self.idle:stop()
+			end
 		end
 	end
 
@@ -494,8 +496,10 @@ function M:run_SingleExecutionEngineAgain(opts)
 				self.numData = self.numData + 1
 				self.list[k] = v
 			end
-			if not self.idle:is_active() then
-				self.idle:start(addSortedDataToTable)
+			if self.idle then
+				if not self.idle:is_active() then
+					self.idle:start(addSortedDataToTable)
+				end
 			end
 		end
 	end

--- a/lua/popfix/fuzzy_engine.lua
+++ b/lua/popfix/fuzzy_engine.lua
@@ -274,17 +274,15 @@ end
 
 function M:new_SingleExecutionEngine()
 	return self:new({
-		run = self.run_SingleExecutionEngine,
+		run = self.run_SingleExecutionEngineAgain,
 		close = self.close_SingleExecutionEngine,
 	})
 end
 
 function M:close_SingleExecutionEngine()
-	if self.promptTimer then
-		self.promptTimer:stop()
-		self.promptTimer:close()
-		self.promptTimer = nil
-	end
+	self.check:stop()
+	self.check:close()
+	self.check = nil
 	if self.job then
 		if self.job then
 			self.job:shutdown()
@@ -369,5 +367,143 @@ function M:new_RepeatedExecutionEngine()
 		close = self.close_RepeatedExecutionEngine,
 	})
 end
+
+function M:run_SingleExecutionEngineAgain(opts)
+	-- initilaization
+	self.sortedList = {}
+	self.list = {}
+	self.manager = opts.manager
+	self.currentPromptText = opts.currentPromptText
+	self.sorter = opts.sorter
+	self.numData = 0
+	self.sortedNumData = 0
+	self.error_handler = opts.error_handler
+	self.startingIndex = 1
+
+
+	-- Additional initilaization job
+	self.scoringFunction = self.sorter.scoringFunction
+	self.filterFunction = self.sorter.filterFunction
+	self.maxJob = self.sorter.maxJob
+	if self.maxJob == nil then
+		self.maxJob = 50
+	end
+	self.sorter = nil
+	-- Our requirements
+	self.manager.currentPromptText = self.currentPromptText
+
+	local function appendAggregateData(itrStart, itrEnd)
+		for cur = itrStart, itrEnd do
+			local line = self.list[cur]
+			if self.currentPromptText == '' then
+				self.sortedNumData = self.sortedNumData + 1
+				self.sortedList[self.sortedNumData] = cur
+				self.manager:add(line, self.sortedNumData, cur)
+			else
+				if self.filterFunction(self.currentPromptText, line,
+					self.caseSensitive) then
+					local score = self.scoringFunction(self.currentPromptText,
+					line, self.caseSensitive)
+					local found = false
+					for k,v in ipairs(self.sortedList) do
+						if score > v.score then
+							found = true
+							self.sortedNumData = self.sortedNumData + 1
+							table.insert(self.sortedList, k, {
+								score = score,
+								index = cur
+							})
+							self.manager:add(line, k, cur)
+							break
+						end
+					end
+					if not found then
+						self.sortedNumData = self.sortedNumData + 1
+						table.insert(self.sortedList, {
+							score = score,
+							index = cur
+						})
+						self.manager:add(line, self.sortedNumData, cur)
+					end
+				end
+			end
+		end
+	end
+
+	local function addSortedDataToTable()
+		if self.numData == 0 then return end
+		local tmp = self.startingIndex
+		local len = self.numData - (self.startingIndex - 1)
+		if len <= 0 then return end
+		if len > self.maxJob then
+			appendAggregateData(tmp, tmp + self.maxJob - 1)
+			self.startingIndex = self.startingIndex + self.maxJob
+		else
+			appendAggregateData(tmp, self.numData)
+			self.startingIndex = self.numData + 1
+		end
+	end
+
+	local function textChanged(prompt)
+		if self.currentPromptText == '' and prompt == '' then
+			return
+		end
+		self.currentPromptText = prompt
+		self.manager.currentPromptText = prompt
+		self.startingIndex = 1
+		self.manager:clear()
+		clear(self.sortedList)
+		self.sortedNumData = 0
+	end
+
+	local function addData(_, line)
+		self.numData = self.numData	+ 1
+		self.list[self.numData] = line
+	end
+
+	local function createJob(data)
+		if data.cmd then
+			local cmd, args = util.getArgs(data.cmd)
+			local cwd = data.cwd or vim.fn.getcwd()
+			self.job = Job:new{
+				command = cmd,
+				args = args,
+				cwd = cwd,
+				on_stdout = addData,
+				on_exit = function()
+					self.job = nil
+				end,
+				on_stderr = function(err, line)
+					self.error_handler(err, line)
+				end
+			}
+			self.job:start()
+		else
+			for k,v in ipairs(data) do
+				self.numData = self.numData + 1
+				self.list[k] = v
+			end
+		end
+	end
+
+	local function setData(data)
+		if self.job then
+			self.job:shutdown()
+			self.job = nil
+		end
+		self.manager:clear()
+		self.numData = 0
+		self.sortedNumData = 0
+		clear(self.list)
+		clear(self.sortedList)
+		createJob(data)
+	end
+	createJob(opts.data)
+	opts = nil
+	self.check = uv.new_check()
+	self.check:start(addSortedDataToTable)
+	return textChanged, setData
+end
+
 
 return M

--- a/lua/popfix/list.lua
+++ b/lua/popfix/list.lua
@@ -145,9 +145,12 @@ function list:clearLast()
 	if self.buffer == nil or self.buffer == 0 then return end
 	local numData = api.nvim_buf_line_count(self.buffer)
 	if vim.fn.bufexists(self.buffer) then
-		api.nvim_buf_set_option(self.buffer, 'modifiable', true)
-		api.nvim_buf_set_lines(self.buffer, numData - 2, numData - 1, false, {})
-		api.nvim_buf_set_option(self.buffer, 'modifiable', false)
+		local buffer = self.buffer
+		vim.schedule(function()
+			api.nvim_buf_set_option(buffer, 'modifiable', true)
+			api.nvim_buf_set_lines(buffer, numData - 2, numData - 1, false, {})
+			api.nvim_buf_set_option(buffer, 'modifiable', false)
+		end)
 	end
 end
 

--- a/lua/popfix/list_manager.lua
+++ b/lua/popfix/list_manager.lua
@@ -34,7 +34,7 @@ function M:select(lineNumber, callback)
 	0, -1)
 	api.nvim_buf_add_highlight(self.list.buffer, listNamespace,
 	"Visual", lineNumber - 1, 0, -1)
-	self.list:select(lineNumber)
+	pcall(self.list.select, self.list, lineNumber)
 	local data
 	if self.sortedList[lineNumber] then
 		data = self.action:select(self.sortedList[lineNumber].index,
@@ -57,7 +57,8 @@ function M:select_next(callback)
 	end
 	if self.currentLineNumber == self.currentlyDisplayed then
 		local line = self.sortedList[self.currentLineNumber + 1].line
-		self.list:addLine(line, self.currentlyDisplayed, self.currentlyDisplayed)
+		pcall(self.list.addLine, self.list, line, self.currentlyDisplayed,
+		self.currentlyDisplayed)
 		local highlight = self.highlightingFunction(self.currentPromptText,
 		line, false)
 		for _, col in pairs(highlight) do
@@ -91,7 +92,7 @@ function M:clear()
 	self.numData = 0
 	self.action:select(nil, nil)
 	vim.schedule(function()
-		self.list:clear()
+		pcall(self.list.clear, self.list)
 		api.nvim_buf_clear_namespace(self.list.buffer, identifier,
 		0, -1)
 	end)
@@ -145,7 +146,7 @@ function M:add(line, index, originalIndex)
 		if add == false then
 			pcall(self.list.clearLast, self.list)
 		end
-		self.list:addLine(line, index - 1, index - 1)
+		pcall(self.list.addLine, self.list, line, index - 1, index - 1)
 		if highlight then
 			for _, col in pairs(highlight) do
 				api.nvim_buf_add_highlight(self.list.buffer, identifier,

--- a/lua/popfix/list_manager.lua
+++ b/lua/popfix/list_manager.lua
@@ -143,7 +143,7 @@ function M:add(line, index, originalIndex)
 	local currentLineNumber = self.currentLineNumber
 	vim.schedule(function()
 		if add == false then
-			self.list:clearLast()
+			pcall(self.list.clearLast, self.list)
 		end
 		self.list:addLine(line, index - 1, index - 1)
 		if highlight then

--- a/lua/popfix/preview.lua
+++ b/lua/popfix/preview.lua
@@ -107,6 +107,7 @@ function preview:writePreview(data)
 	if not self.coloring then
 		api.nvim_win_set_option(self.window, 'winhl', 'Normal:PreviewNormal')
 	end
+	api.nvim_win_set_option(self.window, 'wrap', false)
 
 end
 


### PR DESCRIPTION
Previously single execution fuzzy engine used uv_timer to partition big sorting
job for responsiveness in multiple iterations of the event loop. This not only made
the fuzzy engine responsive for big jobs it made the fuzzy engine way faster
than other pure lua competitors.

However, this also introduced a significant delay of 1ms between each job.
That means if we have a fairly faster sorter, this would not utilize the CPU
resources efficiently.

So, instead of having timer_t for partitioning sorting job into multiple iterations,
this pull request partitions sorting job into multiple iterations using idle_t
that runs in every iteration of the event loop after polling IO.