### PR TITLE
always enter prompt popup in insert mode

### DIFF
--- a/lua/popfix/prompt.lua
+++ b/lua/popfix/prompt.lua
@@ -16,9 +16,11 @@ function prompt:new(opts)
     self.__index = self
     local obj = {}
     setmetatable(obj, self)
+
     if opts.border == nil then
-    opts.border = false
+      opts.border = false
     end
+
     opts.title = opts.title or ''
     opts.height = 1
     opts.prompt_text = opts.prompt_text or ''
@@ -38,17 +40,20 @@ function prompt:new(opts)
     obj.prompt_highlight = opts.prompt_highlight
     api.nvim_buf_add_highlight(obj.buffer, promptHighlightNamespace,
     obj.prompt_highlight, 0, 0, #obj.prefix)
+
     if opts.init_text then
-    obj:setPromptText(opts.init_text)
-    obj.insertStarted = true
+      obj:setPromptText(opts.init_text)
     end
+
     local function startInsert()
-    if not obj.insertStarted then
-	vim.cmd('startinsert')
-	obj.insertStarted = true
+      if not obj.insertStarted then
+        vim.cmd('startinsert')
+        obj.insertStarted = true
+      end
     end
-    end
+
     autocmd.addCommand(obj.buffer, {['BufEnter,WinEnter'] = startInsert})
+
     return obj
 end
 


### PR DESCRIPTION
Currently `prompt` type popups are entered in normal mode if user sets `init_text` to a non-null value. This, IMHO, is not good UX, as it changes behaviour unexpectedly, plus I've never seen cases of usage of normal mode in prompt popus in the wild. This PR fixes that and closes #20.